### PR TITLE
fix: conflictError when multiple Zope instances start simultaneously …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## 1.4.3 (unreleased)
 
 
-- Nothing changed yet.
+- DEVOPS-339 : Fix ConflictError when multiple Zope instances start simultaneously and commit OIDC settings
+  [remdub]
 
 
 ## 1.4.2 (2025-12-10)

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from plone import api
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
 from urllib.parse import urlparse
+from ZODB.POSException import ConflictError
 from zope.annotation.interfaces import IAnnotations
 from zope.component.hooks import setSite
 
@@ -74,8 +75,15 @@ def set_oidc_settings(context):
 
         _set_allowed_groups(oidc)
 
-        transaction.commit()
-        logger.info("OIDC settings set with set_oidc_settings()")
+        try:
+            transaction.commit()
+            logger.info("OIDC settings set with set_oidc_settings()")
+        except ConflictError:
+            transaction.abort()
+            logger.warning(
+                "ConflictError committing OIDC settings: another instance already "
+                "committed the same values. Settings are correct; skipping."
+            )
     else:
         logger.warning("Could not find OIDC plugin, not setting OIDC settings")
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,5 +1,7 @@
 from pas.plugins.kimug import utils
 from plone import api
+from unittest.mock import patch
+from ZODB.POSException import ConflictError
 from zope.annotation.interfaces import IAnnotations
 
 import os
@@ -122,3 +124,20 @@ class TestUtils:
         utils._set_allowed_groups(oidc)
 
         assert oidc.allowed_groups == ("group.1 is - the first!",)
+
+
+class TestSetOidcSettings:
+    def test_conflict_error_is_handled(self, portal):
+        """ConflictError on commit must be caught and transaction aborted — no exception raised."""
+        with patch("pas.plugins.kimug.utils.transaction") as mock_txn:
+            mock_txn.commit.side_effect = ConflictError()
+            utils.set_oidc_settings(None)
+            mock_txn.abort.assert_called_once()
+
+    def test_settings_are_applied(self, portal):
+        """set_oidc_settings should apply environment values to the OIDC plugin."""
+        with patch.dict(os.environ, {"keycloak_client_id": "my-client"}):
+            with patch("pas.plugins.kimug.utils.transaction"):
+                utils.set_oidc_settings(None)
+        oidc = utils.get_plugin()
+        assert oidc.client_id == "my-client"


### PR DESCRIPTION
…and commit OIDC settings

DEVOPS-339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a ConflictError that occurred when multiple Zope instances started simultaneously while committing OIDC settings. The system now gracefully handles the conflict and preserves configuration integrity.

* **Tests**
  * Added test coverage for OIDC settings initialization and conflict scenario handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->