### PR TITLE
feat: upgrade step to set oidc_sso_apps on existing instances

### DIFF
--- a/news/upgrade-1003-oidc-sso-apps.feature.md
+++ b/news/upgrade-1003-oidc-sso-apps.feature.md
@@ -1,0 +1,2 @@
+Add upgrade step (1002→1003) that registers the `oidc_sso_apps` plugin, applies OIDC settings, and syncs SSO Apps users from Keycloak into Plone on existing instances.
+[remdub]

--- a/src/pas/plugins/kimug/controlpanel/classic.py
+++ b/src/pas/plugins/kimug/controlpanel/classic.py
@@ -94,12 +94,20 @@ class KimugSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
 
     def checkSettings(self, plugin="oidc"):
         if not check_keycloak_settings(plugin):
-            return '<div class="alert alert-danger" role="alert">{}</div>'.format(
-                _(
-                    "There is a problem with the Keycloak settings. "
-                    "Please check the Issuer URL, client ID, client secret and redirect_uri"
+            if plugin == "oidc":
+                return '<div class="alert alert-danger" role="alert">{}</div>'.format(
+                    _(
+                        "There is a problem with the Keycloak settings for SSO (plugin oidc)."
+                        "Please check the Issuer URL, client ID, client secret and redirect uri"
+                    )
                 )
-            )
+            elif plugin == "oidc_sso_apps":
+                return '<div class="alert alert-danger" role="alert">{}</div>'.format(
+                    _(
+                        "There is a problem with the Keycloak settings for SSO Apps (plugin oidc_sso_apps). "
+                        "Please check the Issuer URL, client ID and client secret"
+                    )
+                )
         elif plugin == "oidc":
             return '<div class="alert alert-success" role="alert">{}</div>'.format(
                 _(

--- a/src/pas/plugins/kimug/controlpanel/classic.py
+++ b/src/pas/plugins/kimug/controlpanel/classic.py
@@ -97,7 +97,7 @@ class KimugSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
             if plugin == "oidc":
                 return '<div class="alert alert-danger" role="alert">{}</div>'.format(
                     _(
-                        "There is a problem with the Keycloak settings for SSO (plugin oidc)."
+                        "There is a problem with the Keycloak settings for SSO (plugin oidc). "
                         "Please check the Issuer URL, client ID, client secret and redirect uri"
                     )
                 )

--- a/src/pas/plugins/kimug/profiles/default/metadata.xml
+++ b/src/pas/plugins/kimug/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1002</version>
+  <version>1003</version>
 </metadata>

--- a/src/pas/plugins/kimug/upgrades/__init__.py
+++ b/src/pas/plugins/kimug/upgrades/__init__.py
@@ -1,0 +1,17 @@
+from pas.plugins.kimug.setuphandlers import _add_plugin
+from pas.plugins.kimug.utils import add_keycloak_users_to_plone
+from pas.plugins.kimug.utils import get_keycloak_users_from_oidc_sso_apps
+from pas.plugins.kimug.utils import set_oidc_settings
+from plone import api
+
+
+def add_oidc_sso_apps_plugin(context):
+    """Upgrade step to add oidc_sso_apps plugin."""
+    _add_plugin(
+        api.portal.get_tool("acl_users"),
+        pluginid="oidc_sso_apps",
+        title="OIDC SSO Apps",
+    )
+    set_oidc_settings(api.portal.get())
+    users = get_keycloak_users_from_oidc_sso_apps()
+    add_keycloak_users_to_plone(users)

--- a/src/pas/plugins/kimug/upgrades/__init__.py
+++ b/src/pas/plugins/kimug/upgrades/__init__.py
@@ -4,6 +4,11 @@ from pas.plugins.kimug.utils import get_keycloak_users_from_oidc_sso_apps
 from pas.plugins.kimug.utils import set_oidc_settings
 from plone import api
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def add_oidc_sso_apps_plugin(context):
     """Upgrade step to add oidc_sso_apps plugin."""
@@ -13,5 +18,12 @@ def add_oidc_sso_apps_plugin(context):
         title="OIDC SSO Apps",
     )
     set_oidc_settings(api.portal.get())
-    users = get_keycloak_users_from_oidc_sso_apps()
-    add_keycloak_users_to_plone(users)
+    try:
+        users = get_keycloak_users_from_oidc_sso_apps()
+        add_keycloak_users_to_plone(users)
+    except Exception as e:
+        logger.exception(
+            "Keycloak user sync failed during upgrade step; "
+            "plugin registration is complete. Error: %s",
+            e,
+        )

--- a/src/pas/plugins/kimug/upgrades/configure.zcml
+++ b/src/pas/plugins/kimug/upgrades/configure.zcml
@@ -22,4 +22,12 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeStep
+      title="Add oidc_sso_apps plugin"
+      profile="pas.plugins.kimug:default"
+      source="1002"
+      destination="1003"
+      handler=".add_oidc_sso_apps_plugin"
+      />
+
 </configure>

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -771,7 +771,7 @@ def get_keycloak_users_from_oidc():
             return []
 
 
-def get_keycloak_users_from_oidc_sso_apps():
+def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
     """Get Keycloak users from SSO apps."""
     oidc_sso_apps = get_plugin("oidc_sso_apps")
     if not oidc_sso_apps:
@@ -797,11 +797,13 @@ def get_keycloak_users_from_oidc_sso_apps():
         logger.error(
             "Could not get access token from Keycloak with OIDC settings for sso-apps plugin"
         )
-        return None
+        return []
 
     group_url = f"{keycloak_url}admin/realms/{realm}/groups"
     group_response = requests.get(
-        url=group_url, headers={"Authorization": f"Bearer {access_token}"}, timeout=30
+        url=group_url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=timeout,
     )
     group_response.raise_for_status()
 
@@ -817,7 +819,7 @@ def get_keycloak_users_from_oidc_sso_apps():
     users = []
     headers = {"Authorization": f"Bearer {access_token}"}
     try:
-        response = requests.get(url=url, headers=headers, timeout=30)
+        response = requests.get(url=url, headers=headers, timeout=timeout)
         response.raise_for_status()
         users_data = response.json()
 

--- a/tests/setup/test_setup_install.py
+++ b/tests/setup/test_setup_install.py
@@ -16,7 +16,7 @@ class TestSetupInstall:
 
     def test_latest_version(self, profile_last_version):
         """Test latest version of default profile."""
-        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1002"
+        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1003"
 
     def test_acl_users_plugin(self, portal):
         """Test active plugin of acl_users."""

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -256,14 +256,14 @@ class TestGetKeycloakUsersFromOidcSsoApps:
         result = utils.get_keycloak_users_from_oidc_sso_apps()
         assert result == []
 
-    def test_no_access_token_returns_none(self, portal):
-        """If get_client_access_token returns None the function returns None."""
+    def test_no_access_token_returns_empty_list(self, portal):
+        """If get_client_access_token returns None the function returns []."""
         self._configure_plugin()
         with patch(
             "pas.plugins.kimug.utils.get_client_access_token", return_value=None
         ):
             result = utils.get_keycloak_users_from_oidc_sso_apps()
-        assert result is None
+        assert result == []
 
     def test_request_exception_on_groups_fetch_propagates(self, portal):
         """A RequestException on the groups fetch propagates (call is outside try/except)."""


### PR DESCRIPTION
KEYC-77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrade now registers an OIDC SSO Apps plugin and applies OIDC configuration during the 1002→1003 upgrade.
  * Attempts automatic synchronization of SSO Apps users from Keycloak into Plone.

* **Improvements**
  * Keycloak/OIDC error messages are now plugin-specific and clearer.

* **Tests**
  * Updated tests to expect the new upgrade version and adjusted Keycloak-related test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->