### PR TITLE
fix: make the `oidc` plugin handle the interactive login challenge in…

### DIFF
--- a/news/oidc-first-challenge.bugfix.md
+++ b/news/oidc-first-challenge.bugfix.md
@@ -1,0 +1,2 @@
+Make the `oidc` plugin handle the interactive login challenge instead of `oidc_sso_apps`. The `oidc_sso_apps` plugin is now removed from `IChallengePlugin` (it only validates Bearer tokens), and upgrade step 1004→1005 fixes already-installed sites.
+[remdub]

--- a/src/pas/plugins/kimug/profiles/default/metadata.xml
+++ b/src/pas/plugins/kimug/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1004</version>
+  <version>1005</version>
 </metadata>

--- a/src/pas/plugins/kimug/setuphandlers/__init__.py
+++ b/src/pas/plugins/kimug/setuphandlers/__init__.py
@@ -9,6 +9,7 @@ from pas.plugins.kimug.utils import set_oidc_settings
 from pas.plugins.kimug.utils import varenvs_exist
 from plone import api
 from Products.CMFPlone.interfaces import INonInstallable
+from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from zope.interface import implementer
 
 import logging
@@ -29,7 +30,7 @@ class HiddenProfiles:
         ]
 
 
-def _add_plugin(pas, pluginid="oidc", title="OIDC"):
+def _add_plugin(pas, pluginid="oidc", title="OIDC", challenge=True):
     if pluginid in pas.objectIds():
         return pluginid + " already installed."
     plugin = KimugPlugin(pluginid, title=title)
@@ -43,6 +44,13 @@ def _add_plugin(pas, pluginid="oidc", title="OIDC"):
         pas.plugins.movePluginsDown(
             interface, [x[0] for x in pas.plugins.listPlugins(interface)[:-1]]
         )
+    if not challenge:
+        # This plugin only validates Bearer tokens; it must not challenge
+        # browser users (that would redirect to the wrong login). Leave the
+        # interactive login challenge to the "oidc" plugin.
+        active = [x[0] for x in pas.plugins.listPlugins(IChallengePlugin)]
+        if pluginid in active:
+            pas.plugins.deactivatePlugin(IChallengePlugin, pluginid)
 
 
 def post_install(context):
@@ -54,6 +62,7 @@ def post_install(context):
         api.portal.get_tool("acl_users"),
         pluginid="oidc_sso_apps",
         title="OIDC SSO Apps",
+        challenge=False,
     )
 
     set_oidc_settings(context)

--- a/src/pas/plugins/kimug/upgrades/__init__.py
+++ b/src/pas/plugins/kimug/upgrades/__init__.py
@@ -3,6 +3,7 @@ from pas.plugins.kimug.utils import add_keycloak_users_to_plone
 from pas.plugins.kimug.utils import get_keycloak_users_from_oidc_sso_apps
 from pas.plugins.kimug.utils import set_oidc_settings
 from plone import api
+from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 
 import logging
 
@@ -16,6 +17,7 @@ def add_oidc_sso_apps_plugin(context):
         api.portal.get_tool("acl_users"),
         pluginid="oidc_sso_apps",
         title="OIDC SSO Apps",
+        challenge=False,
     )
     set_oidc_settings(api.portal.get())
     try:
@@ -27,3 +29,16 @@ def add_oidc_sso_apps_plugin(context):
             "plugin registration is complete. Error: %s",
             e,
         )
+
+
+def disable_oidc_sso_apps_challenge(context):
+    """Remove oidc_sso_apps from IChallengePlugin so oidc handles the login.
+
+    On sites where oidc_sso_apps was already installed, the previous
+    registration left it on top of the IChallengePlugin list, hijacking the
+    interactive login challenge from the "oidc" plugin.
+    """
+    pas = api.portal.get_tool("acl_users")
+    active = [p[0] for p in pas.plugins.listPlugins(IChallengePlugin)]
+    if "oidc_sso_apps" in active:
+        pas.plugins.deactivatePlugin(IChallengePlugin, "oidc_sso_apps")

--- a/src/pas/plugins/kimug/upgrades/configure.zcml
+++ b/src/pas/plugins/kimug/upgrades/configure.zcml
@@ -49,4 +49,12 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeStep
+      title="Disable oidc_sso_apps challenge so oidc handles the login"
+      profile="pas.plugins.kimug:default"
+      source="1004"
+      destination="1005"
+      handler=".disable_oidc_sso_apps_challenge"
+      />
+
 </configure>

--- a/tests/setup/test_setup_install.py
+++ b/tests/setup/test_setup_install.py
@@ -16,7 +16,7 @@ class TestSetupInstall:
 
     def test_latest_version(self, profile_last_version):
         """Test latest version of default profile."""
-        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1004"
+        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1005"
 
     def test_acl_users_plugin(self, portal):
         """Test active plugin of acl_users."""
@@ -30,3 +30,13 @@ class TestSetupInstall:
     def test_oidc_sso_apps_plugin_installed(self, portal):
         """oidc_sso_apps plugin should be installed in acl_users after post_install."""
         assert "oidc_sso_apps" in portal.acl_users.objectIds()
+
+    def test_oidc_is_first_challenge_plugin(self, portal):
+        """oidc must handle the login challenge; oidc_sso_apps must not challenge."""
+        from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
+
+        pas = portal.acl_users
+        challenge_plugins = [p[0] for p in pas.plugins.listPlugins(IChallengePlugin)]
+        assert "oidc" in challenge_plugins
+        assert "oidc_sso_apps" not in challenge_plugins
+        assert challenge_plugins[0] == "oidc"


### PR DESCRIPTION
…stead of `oidc_sso_apps`

KEYC-77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an authentication configuration issue where the OIDC plugin now exclusively handles interactive login challenges, improving security and preventing conflicts with secondary authentication mechanisms.

* **Documentation**
  * Updated release notes documenting configuration changes and authentication plugin behavior improvements in this upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->