### PR TITLE
Jwks cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### Bug fixes:
 
 - Fix sticky `403 Forbidden` on token authentication: the JWKS signing-key client was a single class-level cache shared by both the `oidc` and `sso-apps` realms. A request would receive a client built for the other realm, whose `kid` is never in the cached keyset, forcing a live JWKS refetch on essentially every request. That fetch storm could trip the Keycloak proxy's rate-limiter into returning 403, and PyJWT clearing its keyset cache on each failed fetch kept it failing until a restart. JWKS clients are now cached per realm. [remdub]
+- Add a per-realm JWKS failure backoff: after a failed signing-key fetch, further fetches for that realm are skipped for a short cooldown, so a transient 403 from the Keycloak proxy can no longer become a self-sustaining retry storm. Authentication for the realm recovers automatically once the endpoint is healthy again, without a restart. [remdub]
 
 
 ## 1.6.3 (2026-06-09)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 ## 1.6.4 (unreleased)
 
 
-- Nothing changed yet.
+### Bug fixes:
+
+- Fix sticky `403 Forbidden` on token authentication: the JWKS signing-key client was a single class-level cache shared by both the `oidc` and `sso-apps` realms. A request would receive a client built for the other realm, whose `kid` is never in the cached keyset, forcing a live JWKS refetch on essentially every request. That fetch storm could trip the Keycloak proxy's rate-limiter into returning 403, and PyJWT clearing its keyset cache on each failed fetch kept it failing until a restart. JWKS clients are now cached per realm. [remdub]
 
 
 ## 1.6.3 (2026-06-09)

--- a/src/pas/plugins/kimug/plugin/__init__.py
+++ b/src/pas/plugins/kimug/plugin/__init__.py
@@ -56,6 +56,14 @@ class KimugPlugin(OIDCPlugin):
     _jwks_clients_created_at = {}  # plugin id -> float (epoch)
     _JWKS_CLIENT_TTL = 3600
 
+    # Per-realm JWKS failure backoff. After a failed fetch we skip further
+    # fetches for ``_JWKS_FAILURE_COOLDOWN`` seconds, so a transient 403 from
+    # the Keycloak proxy is not turned into a self-sustaining retry storm
+    # (PyJWT clears its keyset cache on every failed fetch, which otherwise
+    # makes the next request fetch again).
+    _jwks_failed_at = {}  # plugin id -> epoch of last JWKS fetch failure
+    _JWKS_FAILURE_COOLDOWN = 30  # seconds to skip JWKS fetches after a failure
+
     add_user_url: str = ""
     personal_information_url: str = ""
     change_password_url: str = ""
@@ -247,18 +255,32 @@ class KimugPlugin(OIDCPlugin):
         authentication chain fall through to other plugins instead of
         propagating to HTTP 500.
         """
+        cls = KimugPlugin
+        now = time.time()
+        failed_at = cls._jwks_failed_at.get(plugin)
+        if failed_at is not None and now - failed_at < cls._JWKS_FAILURE_COOLDOWN:
+            if is_log_active():
+                logger.info(
+                    f"_decode_token: JWKS for plugin='{plugin}' in failure cooldown "
+                    f"({now - failed_at:.0f}s/{cls._JWKS_FAILURE_COOLDOWN}s), "
+                    f"skipping fetch"
+                )
+            return None
         try:
-            # __import__("ipdb").set_trace()
             signing_key = self._get_jwks_client(plugin=plugin).get_signing_key_from_jwt(
                 token
             )
         except PyJWKClientError as exc:
+            cls._jwks_failed_at[plugin] = now
             logger.info("JWKS lookup failed: %s", exc)
             return None
         except Exception as exc:
             # Network, DNS, or misconfiguration. Degrade gracefully.
+            cls._jwks_failed_at[plugin] = now
             logger.warning("JWKS unreachable: %s", exc)
             return None
+        # JWKS endpoint is reachable again; clear any prior failure backoff.
+        cls._jwks_failed_at.pop(plugin, None)
 
         if plugin == "oidc":
             issuer = os.environ.get("keycloak_issuer")

--- a/src/pas/plugins/kimug/plugin/__init__.py
+++ b/src/pas/plugins/kimug/plugin/__init__.py
@@ -47,10 +47,13 @@ class KimugPlugin(OIDCPlugin):
     meta_type = "Kimug Plugin"
     _dont_swallow_my_exceptions = True
 
-    # JWKS client cache. Refreshed after ``_JWKS_CLIENT_TTL`` seconds so key
-    # rotations on the Keycloak side are picked up without a restart.
-    _jwks_client = None
-    _jwks_client_created_at = 0.0
+    # JWKS clients cached per realm (keyed by plugin id). Refreshed after
+    # ``_JWKS_CLIENT_TTL`` seconds so key rotations on the Keycloak side are
+    # picked up without a restart. A single shared client would be handed to
+    # both the ``oidc`` and ``oidc_sso_apps`` realms, whose tokens then never
+    # match the cached keyset and force a JWKS refetch on every request.
+    _jwks_clients = {}  # plugin id -> PyJWKClient
+    _jwks_clients_created_at = {}  # plugin id -> float (epoch)
     _JWKS_CLIENT_TTL = 3600
 
     add_user_url: str = ""
@@ -198,10 +201,8 @@ class KimugPlugin(OIDCPlugin):
         # Reference the real class explicitly.
         cls = KimugPlugin
         now = time.time()
-        if (
-            cls._jwks_client is None
-            or now - cls._jwks_client_created_at > cls._JWKS_CLIENT_TTL
-        ):
+        created_at = cls._jwks_clients_created_at.get(plugin, 0.0)
+        if plugin not in cls._jwks_clients or now - created_at > cls._JWKS_CLIENT_TTL:
             if plugin == "oidc":
                 keycloak_url = os.environ.get(
                     "keycloak_url", "https://keycloak.127.0.0.1.nip.io/"
@@ -218,20 +219,24 @@ class KimugPlugin(OIDCPlugin):
                 realm = os.environ.get("SSO_APPS_REALM", "sso-apps")
             jwks_url = f"{keycloak_url}/realms/{realm}/protocol/openid-connect/certs"
             if is_log_active():
-                logger.info(f"_get_jwks_client: rebuilding JWKS client for {jwks_url}")
-            cls._jwks_client = PyJWKClient(
+                logger.info(
+                    f"_get_jwks_client: rebuilding JWKS client "
+                    f"for plugin='{plugin}' ({jwks_url})"
+                )
+            cls._jwks_clients[plugin] = PyJWKClient(
                 jwks_url,
                 cache_keys=True,
                 lifespan=cls._JWKS_CLIENT_TTL,
                 timeout=5,
             )
-            cls._jwks_client_created_at = now
+            cls._jwks_clients_created_at[plugin] = now
         elif is_log_active():
-            age = now - cls._jwks_client_created_at
+            age = now - created_at
             logger.info(
-                f"_get_jwks_client: reusing cached JWKS client (age={age:.0f}s)"
+                f"_get_jwks_client: reusing cached JWKS client "
+                f"for plugin='{plugin}' (age={age:.0f}s)"
             )
-        return cls._jwks_client
+        return cls._jwks_clients[plugin]
 
     def _decode_token(self, token, plugin="oidc"):
         """Decode and fully verify a Keycloak-issued RS256 JWT.

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -5,10 +5,31 @@ from unittest.mock import patch
 
 import jwt
 import os
+import pytest
 import requests
 
 
 class TestPlugin:
+    @pytest.fixture(autouse=True)
+    def _isolate_jwks_class_state(self):
+        """Snapshot and restore KimugPlugin's mutable class-level JWKS caches so
+        tests that mutate them do not leak state into later tests."""
+        from pas.plugins.kimug.plugin import KimugPlugin
+
+        saved = {
+            attr: dict(getattr(KimugPlugin, attr))
+            for attr in (
+                "_jwks_clients",
+                "_jwks_clients_created_at",
+                "_jwks_failed_at",
+            )
+        }
+        yield
+        for attr, original in saved.items():
+            live = getattr(KimugPlugin, attr)
+            live.clear()
+            live.update(original)
+
     def _initialize(self, portal):
         pas = api.portal.get_tool("acl_users")
         plugin = getattr(pas, "oidc")

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -406,3 +406,59 @@ class TestPlugin:
         # Same realm returns the cached instance rather than rebuilding.
         assert plugin._get_jwks_client(plugin="oidc") is oidc_client
         assert plugin._get_jwks_client(plugin="oidc_sso_apps") is sso_client
+
+    def test_decode_token_failure_triggers_cooldown(self, portal):
+        """After a JWKS failure, an immediate retry must short-circuit without
+        hitting the endpoint again — this is the backoff that prevents a
+        transient 403 from becoming a self-sustaining fetch storm.
+        """
+        from jwt.exceptions import PyJWKClientError
+        from pas.plugins.kimug.plugin import KimugPlugin
+
+        KimugPlugin._jwks_failed_at.clear()
+        plugin = portal.acl_users.oidc
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.side_effect = PyJWKClientError("boom")
+        with patch.object(plugin, "_get_jwks_client", return_value=mock_client):
+            first = plugin._decode_token("fake.token", plugin="oidc")
+            second = plugin._decode_token("fake.token", plugin="oidc")
+        assert first is None
+        assert second is None
+        # Second call was suppressed by the cooldown, so only one fetch attempt.
+        assert mock_client.get_signing_key_from_jwt.call_count == 1
+        assert "oidc" in KimugPlugin._jwks_failed_at
+
+    def test_decode_token_retries_after_cooldown_elapsed(self, portal):
+        """Once the cooldown window has passed, the next call must attempt the
+        JWKS fetch again rather than staying suppressed forever.
+        """
+        from jwt.exceptions import PyJWKClientError
+        from pas.plugins.kimug.plugin import KimugPlugin
+
+        # Mark a failure far enough in the past that the cooldown has elapsed.
+        KimugPlugin._jwks_failed_at["oidc"] = 0.0
+        plugin = portal.acl_users.oidc
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.side_effect = PyJWKClientError("boom")
+        with patch.object(plugin, "_get_jwks_client", return_value=mock_client):
+            result = plugin._decode_token("fake.token", plugin="oidc")
+        assert result is None
+        assert mock_client.get_signing_key_from_jwt.call_count == 1
+
+    def test_decode_token_success_clears_cooldown(self, portal, monkeypatch):
+        """A successful key fetch must clear any prior failure marker so the
+        realm is not left in a stale backoff state.
+        """
+        from pas.plugins.kimug.plugin import KimugPlugin
+
+        KimugPlugin._jwks_failed_at["oidc"] = 0.0
+        plugin = portal.acl_users.oidc
+        mock_key = MagicMock()
+        mock_key.key = "key"
+        mock_client = MagicMock()
+        mock_client.get_signing_key_from_jwt.return_value = mock_key
+        with patch.object(plugin, "_get_jwks_client", return_value=mock_client), patch(
+            "pas.plugins.kimug.plugin.jwt.decode", return_value={"sub": "x"}
+        ):
+            plugin._decode_token("fake.token", plugin="oidc")
+        assert "oidc" not in KimugPlugin._jwks_failed_at

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -375,3 +375,34 @@ class TestPlugin:
             mock_client.return_value.get_signing_key_from_jwt.return_value = mock_key
             plugin._decode_token("fake.token", plugin="oidc_sso_apps")
         assert mock_decode.call_args.kwargs["audience"] == "explicit-audience"
+
+    def test_get_jwks_client_cached_per_realm(self, portal, monkeypatch):
+        """Each realm must get its own JWKS client. A single shared client would
+        be handed to the wrong realm, whose tokens never match the cached keyset
+        and force a JWKS refetch on every request (the cause of the sticky 403).
+        """
+        from pas.plugins.kimug.plugin import KimugPlugin
+
+        # PyJWKClient does no network I/O at construction, so this is offline.
+        monkeypatch.setenv("keycloak_url", "https://kc-oidc.example.com/")
+        monkeypatch.setenv("keycloak_realm", "plone")
+        monkeypatch.setenv("SSO_APPS_URL", "https://kc-sso.example.com/")
+        monkeypatch.setenv("SSO_APPS_REALM", "sso-apps")
+        # Start from a clean class-level cache for a deterministic assertion.
+        KimugPlugin._jwks_clients.clear()
+        KimugPlugin._jwks_clients_created_at.clear()
+
+        plugin = portal.acl_users.oidc
+        oidc_client = plugin._get_jwks_client(plugin="oidc")
+        sso_client = plugin._get_jwks_client(plugin="oidc_sso_apps")
+
+        assert oidc_client is not sso_client
+        assert oidc_client.uri == (
+            "https://kc-oidc.example.com/realms/plone/protocol/openid-connect/certs"
+        )
+        assert sso_client.uri == (
+            "https://kc-sso.example.com/realms/sso-apps/protocol/openid-connect/certs"
+        )
+        # Same realm returns the cached instance rather than rebuilding.
+        assert plugin._get_jwks_client(plugin="oidc") is oidc_client
+        assert plugin._get_jwks_client(plugin="oidc_sso_apps") is sso_client


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC/SSO authentication stability by avoiding shared JWKS client reuse across realms and reducing unnecessary signing-key refetches.
  * Added per-realm failure backoff to prevent retry storms and allow automatic recovery when JWKS endpoints become healthy.

* **Tests**
  * Added tests covering realm-scoped JWKS caching and cooldown/backoff behavior.

* **Documentation**
  * Updated changelog with the above fixes for release 1.6.4 (unreleased).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->