### PR TITLE
feat: restrict the SSO-apps user sync to members of an organisation-s…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 
 ### New features:
 
-- Restrict the SSO-apps user sync to members of an organisation-specific PL group: `get_keycloak_users_from_oidc_sso_apps` now only imports access-group members that also belong to one of the groups listed in the `SSO_APPS_PL_GROUPS` environment variable (e.g. `[pl_belleville_ac]`). When the variable is unset, all access-group members are imported as before. [remdub]
+- Restrict the SSO-apps user sync to members of an organisation-specific municipality group: `get_keycloak_users_from_oidc_sso_apps` now only imports access-group members that also belong to one of the groups listed in the `SSO_APPS_MUNICIPALITY_GROUPS` environment variable (e.g. `[pl_belleville_ac]`). When the variable is unset, all access-group members are imported as before. [remdub]
 
 
 ### Bug fixes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ## 1.6.4 (unreleased)
 
 
+### New features:
+
+- Restrict the SSO-apps user sync to members of an organisation-specific PL group: `get_keycloak_users_from_oidc_sso_apps` now only imports access-group members that also belong to one of the groups listed in the `SSO_APPS_PL_GROUPS` environment variable (e.g. `[pl_belleville_ac]`). When the variable is unset, all access-group members are imported as before. [remdub]
+
+
 ### Bug fixes:
 
 - Fix sticky `403 Forbidden` on token authentication: the JWKS signing-key client was a single class-level cache shared by both the `oidc` and `sso-apps` realms. A request would receive a client built for the other realm, whose `kid` is never in the cached keyset, forcing a live JWKS refetch on essentially every request. That fetch storm could trip the Keycloak proxy's rate-limiter into returning 403, and PyJWT clearing its keyset cache on each failed fetch kept it failing until a restart. JWKS clients are now cached per realm. [remdub]

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -827,16 +827,45 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
             group_id = group.get("id")
             break
 
+    # Optionally restrict to users who are also members of an organisation-specific
+    # PL group (e.g. "pl_belleville_ac"), set by puppet as "[group1, group2]".
+    pl_groups_env = os.environ.get("SSO_APPS_PL_GROUPS")
+    pl_group_names = _parse_bracketed_env_list(pl_groups_env) if pl_groups_env else []
+
     url = f"{keycloak_url}admin/realms/{realm}/groups/{group_id}/members?max=100000"
     users = []
     headers = {"Authorization": f"Bearer {access_token}"}
     try:
+        # When PL groups are configured, build the set of keycloak ids that belong
+        # to at least one of them; only those users will be imported.
+        pl_member_ids = None  # None => no PL filtering
+        if pl_group_names:
+            pl_group_ids = [g["id"] for g in groups if g.get("name") in pl_group_names]
+            if not pl_group_ids:
+                logger.error(
+                    f"PL groups {pl_group_names} not found in Keycloak realm '{realm}'"
+                )
+                return []
+            pl_member_ids = set()
+            for pl_group_id in pl_group_ids:
+                pl_url = (
+                    f"{keycloak_url}admin/realms/{realm}/groups/"
+                    f"{pl_group_id}/members?max=100000"
+                )
+                pl_resp = requests.get(url=pl_url, headers=headers, timeout=timeout)
+                pl_resp.raise_for_status()
+                for member in pl_resp.json():
+                    if member.get("id"):
+                        pl_member_ids.add(member["id"])
+
         response = requests.get(url=url, headers=headers, timeout=timeout)
         response.raise_for_status()
         users_data = response.json()
 
         # Extract username and email from each user
         for user in users_data:
+            if pl_member_ids is not None and user.get("id") not in pl_member_ids:
+                continue
             user_info = {
                 "username": user.get("username", ""),
                 "email": user.get("email", ""),
@@ -930,6 +959,17 @@ def remove_authentic_users(context=None) -> None:
     )
     portal_membership.deleteMembers(users_to_delete, delete_localroles=0)
     transaction.commit()
+
+
+def _parse_bracketed_env_list(value: str) -> list[str]:
+    """Parse a puppet-rendered list env var like '[a, b]' into a list of names.
+
+    Handles the bracketed comma-space form '[a, b]' and a single bare value 'a'.
+    """
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    return [v for v in value.split(", ") if v]
 
 
 def _set_allowed_groups(oidc) -> None:

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -828,35 +828,43 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
             break
 
     # Optionally restrict to users who are also members of an organisation-specific
-    # PL group (e.g. "pl_belleville_ac"), set by puppet as "[group1, group2]".
-    pl_groups_env = os.environ.get("SSO_APPS_PL_GROUPS")
-    pl_group_names = _parse_bracketed_env_list(pl_groups_env) if pl_groups_env else []
+    # Municipality group (e.g. "pl_belleville_ac"), set by puppet as "[group1, group2]".
+    municipality_groups_env = os.environ.get("SSO_APPS_MUNICIPALITY_GROUPS")
+    municipality_group_names = (
+        _parse_bracketed_env_list(municipality_groups_env)
+        if municipality_groups_env
+        else []
+    )
 
     url = f"{keycloak_url}admin/realms/{realm}/groups/{group_id}/members?max=100000"
     users = []
     headers = {"Authorization": f"Bearer {access_token}"}
     try:
-        # When PL groups are configured, build the set of keycloak ids that belong
+        # When Municipality groups are configured, build the set of keycloak ids that belong
         # to at least one of them; only those users will be imported.
-        pl_member_ids = None  # None => no PL filtering
-        if pl_group_names:
-            pl_group_ids = [g["id"] for g in groups if g.get("name") in pl_group_names]
-            if not pl_group_ids:
+        municipality_member_ids = None  # None => no PL filtering
+        if municipality_group_names:
+            municipality_group_ids = [
+                g["id"] for g in groups if g.get("name") in municipality_group_names
+            ]
+            if not municipality_group_ids:
                 logger.error(
-                    f"PL groups {pl_group_names} not found in Keycloak realm '{realm}'"
+                    f"Municipality groups {municipality_group_names} not found in Keycloak realm '{realm}'"
                 )
                 return []
-            pl_member_ids = set()
-            for pl_group_id in pl_group_ids:
-                pl_url = (
+            municipality_member_ids = set()
+            for municipality_group_id in municipality_group_ids:
+                municipality_url = (
                     f"{keycloak_url}admin/realms/{realm}/groups/"
-                    f"{pl_group_id}/members?max=100000"
+                    f"{municipality_group_id}/members?max=100000"
                 )
-                pl_resp = requests.get(url=pl_url, headers=headers, timeout=timeout)
+                pl_resp = requests.get(
+                    url=municipality_url, headers=headers, timeout=timeout
+                )
                 pl_resp.raise_for_status()
                 for member in pl_resp.json():
                     if member.get("id"):
-                        pl_member_ids.add(member["id"])
+                        municipality_member_ids.add(member["id"])
 
         response = requests.get(url=url, headers=headers, timeout=timeout)
         response.raise_for_status()
@@ -864,7 +872,10 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
 
         # Extract username and email from each user
         for user in users_data:
-            if pl_member_ids is not None and user.get("id") not in pl_member_ids:
+            if (
+                municipality_member_ids is not None
+                and user.get("id") not in municipality_member_ids
+            ):
                 continue
             user_info = {
                 "username": user.get("username", ""),

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -858,11 +858,11 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
                     f"{keycloak_url}admin/realms/{realm}/groups/"
                     f"{municipality_group_id}/members?max=100000"
                 )
-                pl_resp = requests.get(
+                municipality_resp = requests.get(
                     url=municipality_url, headers=headers, timeout=timeout
                 )
-                pl_resp.raise_for_status()
-                for member in pl_resp.json():
+                municipality_resp.raise_for_status()
+                for member in municipality_resp.json():
                     if member.get("id"):
                         municipality_member_ids.add(member["id"])
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -383,9 +383,9 @@ class TestGetKeycloakUsersFromOidcSsoApps:
                 result = utils.get_keycloak_users_from_oidc_sso_apps()
         assert result == []
 
-    def test_pl_group_filtering_keeps_only_pl_members(self, portal):
-        """With SSO_APPS_PL_GROUPS set, only access-group members that are also in a
-        PL group are imported."""
+    def test_municipality_group_filtering_keeps_only_pl_members(self, portal):
+        """With SSO_APPS_MUNICIPALITY_GROUPS set, only access-group members that are also in a
+        Municipality group are imported."""
         self._configure_plugin()
         groups = [
             {"id": "grp-access", "name": "access_imio-apps-kimug"},
@@ -396,7 +396,9 @@ class TestGetKeycloakUsersFromOidcSsoApps:
             {"id": "uid-1", "username": "alice", "email": "alice@example.com"},
             {"id": "uid-2", "username": "bob", "email": "bob@example.com"},
         ]
-        with patch.dict(os.environ, {"SSO_APPS_PL_GROUPS": "[pl_belleville_ac]"}):
+        with patch.dict(
+            os.environ, {"SSO_APPS_MUNICIPALITY_GROUPS": "[pl_belleville_ac]"}
+        ):
             with patch(
                 "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
             ):
@@ -411,14 +413,14 @@ class TestGetKeycloakUsersFromOidcSsoApps:
         usernames = [u["username"] for u in result]
         assert usernames == ["alice"]
         # The PL members are fetched before the access-group members.
-        pl_url = mock_get.call_args_list[1].kwargs["url"]
-        assert "grp-pl" in pl_url
+        municipality_url = mock_get.call_args_list[1].kwargs["url"]
+        assert "grp-pl" in municipality_url
 
-    def test_pl_group_not_found_returns_empty_list(self, portal):
-        """If a configured PL group does not exist in the realm, no user qualifies."""
+    def test_municipality_group_not_found_returns_empty_list(self, portal):
+        """If a configured Municipality group does not exist in the realm, no user qualifies."""
         self._configure_plugin()
         groups = [{"id": "grp-access", "name": "access_imio-apps-kimug"}]
-        with patch.dict(os.environ, {"SSO_APPS_PL_GROUPS": "[pl_missing]"}):
+        with patch.dict(os.environ, {"SSO_APPS_MUNICIPALITY_GROUPS": "[pl_missing]"}):
             with patch(
                 "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
             ):
@@ -427,8 +429,8 @@ class TestGetKeycloakUsersFromOidcSsoApps:
                     result = utils.get_keycloak_users_from_oidc_sso_apps()
         assert result == []
 
-    def test_multiple_pl_groups_membership_in_either_qualifies(self, portal):
-        """A user in any one of the configured PL groups is imported."""
+    def test_multiple_municipality_groups_membership_in_either_qualifies(self, portal):
+        """A user in any one of the configured Municipality groups is imported."""
         self._configure_plugin()
         groups = [
             {"id": "grp-access", "name": "access_imio-apps-kimug"},
@@ -443,7 +445,8 @@ class TestGetKeycloakUsersFromOidcSsoApps:
             {"id": "uid-3", "username": "carol", "email": "carol@example.com"},
         ]
         with patch.dict(
-            os.environ, {"SSO_APPS_PL_GROUPS": "[pl_belleville_ac, pl_another_ic]"}
+            os.environ,
+            {"SSO_APPS_MUNICIPALITY_GROUPS": "[pl_belleville_ac, pl_another_ic]"},
         ):
             with patch(
                 "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -383,6 +383,83 @@ class TestGetKeycloakUsersFromOidcSsoApps:
                 result = utils.get_keycloak_users_from_oidc_sso_apps()
         assert result == []
 
+    def test_pl_group_filtering_keeps_only_pl_members(self, portal):
+        """With SSO_APPS_PL_GROUPS set, only access-group members that are also in a
+        PL group are imported."""
+        self._configure_plugin()
+        groups = [
+            {"id": "grp-access", "name": "access_imio-apps-kimug"},
+            {"id": "grp-pl", "name": "pl_belleville_ac"},
+        ]
+        pl_members = [{"id": "uid-1", "username": "alice"}]
+        access_members = [
+            {"id": "uid-1", "username": "alice", "email": "alice@example.com"},
+            {"id": "uid-2", "username": "bob", "email": "bob@example.com"},
+        ]
+        with patch.dict(os.environ, {"SSO_APPS_PL_GROUPS": "[pl_belleville_ac]"}):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [
+                        self._mock_response(groups),
+                        self._mock_response(pl_members),
+                        self._mock_response(access_members),
+                    ]
+                    result = utils.get_keycloak_users_from_oidc_sso_apps()
+
+        usernames = [u["username"] for u in result]
+        assert usernames == ["alice"]
+        # The PL members are fetched before the access-group members.
+        pl_url = mock_get.call_args_list[1].kwargs["url"]
+        assert "grp-pl" in pl_url
+
+    def test_pl_group_not_found_returns_empty_list(self, portal):
+        """If a configured PL group does not exist in the realm, no user qualifies."""
+        self._configure_plugin()
+        groups = [{"id": "grp-access", "name": "access_imio-apps-kimug"}]
+        with patch.dict(os.environ, {"SSO_APPS_PL_GROUPS": "[pl_missing]"}):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [self._mock_response(groups)]
+                    result = utils.get_keycloak_users_from_oidc_sso_apps()
+        assert result == []
+
+    def test_multiple_pl_groups_membership_in_either_qualifies(self, portal):
+        """A user in any one of the configured PL groups is imported."""
+        self._configure_plugin()
+        groups = [
+            {"id": "grp-access", "name": "access_imio-apps-kimug"},
+            {"id": "grp-pl1", "name": "pl_belleville_ac"},
+            {"id": "grp-pl2", "name": "pl_another_ic"},
+        ]
+        pl1_members = [{"id": "uid-1", "username": "alice"}]
+        pl2_members = [{"id": "uid-2", "username": "bob"}]
+        access_members = [
+            {"id": "uid-1", "username": "alice", "email": "alice@example.com"},
+            {"id": "uid-2", "username": "bob", "email": "bob@example.com"},
+            {"id": "uid-3", "username": "carol", "email": "carol@example.com"},
+        ]
+        with patch.dict(
+            os.environ, {"SSO_APPS_PL_GROUPS": "[pl_belleville_ac, pl_another_ic]"}
+        ):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [
+                        self._mock_response(groups),
+                        self._mock_response(pl1_members),
+                        self._mock_response(pl2_members),
+                        self._mock_response(access_members),
+                    ]
+                    result = utils.get_keycloak_users_from_oidc_sso_apps()
+
+        usernames = sorted(u["username"] for u in result)
+        assert usernames == ["alice", "bob"]
+
 
 class TestSetOidcSettings:
     def test_conflict_error_is_handled(self, portal):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -383,15 +383,15 @@ class TestGetKeycloakUsersFromOidcSsoApps:
                 result = utils.get_keycloak_users_from_oidc_sso_apps()
         assert result == []
 
-    def test_municipality_group_filtering_keeps_only_pl_members(self, portal):
+    def test_municipality_group_filtering_keeps_only_municipality_members(self, portal):
         """With SSO_APPS_MUNICIPALITY_GROUPS set, only access-group members that are also in a
         Municipality group are imported."""
         self._configure_plugin()
         groups = [
             {"id": "grp-access", "name": "access_imio-apps-kimug"},
-            {"id": "grp-pl", "name": "pl_belleville_ac"},
+            {"id": "grp-municipality", "name": "pl_belleville_ac"},
         ]
-        pl_members = [{"id": "uid-1", "username": "alice"}]
+        municipality_members = [{"id": "uid-1", "username": "alice"}]
         access_members = [
             {"id": "uid-1", "username": "alice", "email": "alice@example.com"},
             {"id": "uid-2", "username": "bob", "email": "bob@example.com"},
@@ -405,7 +405,7 @@ class TestGetKeycloakUsersFromOidcSsoApps:
                 with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
                     mock_get.side_effect = [
                         self._mock_response(groups),
-                        self._mock_response(pl_members),
+                        self._mock_response(municipality_members),
                         self._mock_response(access_members),
                     ]
                     result = utils.get_keycloak_users_from_oidc_sso_apps()
@@ -414,7 +414,7 @@ class TestGetKeycloakUsersFromOidcSsoApps:
         assert usernames == ["alice"]
         # The PL members are fetched before the access-group members.
         municipality_url = mock_get.call_args_list[1].kwargs["url"]
-        assert "grp-pl" in municipality_url
+        assert "grp-municipality" in municipality_url
 
     def test_municipality_group_not_found_returns_empty_list(self, portal):
         """If a configured Municipality group does not exist in the realm, no user qualifies."""
@@ -434,8 +434,8 @@ class TestGetKeycloakUsersFromOidcSsoApps:
         self._configure_plugin()
         groups = [
             {"id": "grp-access", "name": "access_imio-apps-kimug"},
-            {"id": "grp-pl1", "name": "pl_belleville_ac"},
-            {"id": "grp-pl2", "name": "pl_another_ic"},
+            {"id": "grp-municipality1", "name": "pl_belleville_ac"},
+            {"id": "grp-municipality2", "name": "pl_another_ic"},
         ]
         pl1_members = [{"id": "uid-1", "username": "alice"}]
         pl2_members = [{"id": "uid-2", "username": "bob"}]


### PR DESCRIPTION
…pecific PL group

KEYC-77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSO app user imports can optionally be restricted to users who also belong to configured municipality/PL groups. When this setting is not provided, imports behave as before. If configured groups are not found, no users are imported.

* **Tests**
  * Added tests for filtered imports, missing-group behavior, multi-group union handling, and deterministic ordering of results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->