### PR TITLE
Key 77 runscripts set permissions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 - Restrict the SSO-apps user sync to members of an organisation-specific municipality group: `get_keycloak_users_from_oidc_sso_apps` now only imports access-group members that also belong to one of the groups listed in the `SSO_APPS_MUNICIPALITY_GROUPS` environment variable (e.g. `[pl_belleville_ac]`). When the variable is unset, all access-group members are imported as before. [remdub]
 
+- Browser view (with run and dry-run buttons in the control panel) and thin `scripts/set_sso_apps_permissions.py` runscript to set roles on authentic sources from sso apps. [remdub]
+
 
 ### Bug fixes:
 

--- a/news/sso-apps-municipalities.feature.md
+++ b/news/sso-apps-municipalities.feature.md
@@ -1,0 +1,1 @@
+Add `get_sso_apps_users_with_municipalities` utility (and the `_municipality_from_group_name` helper) that returns each access-group sso-apps user enriched with the municipality slugs derived from their `pl_<localite>` Keycloak groups. Intended to be called from a maintenance runscript that grants those users local roles on the matching Plone root folder. [remdub]

--- a/news/sso-apps-municipalities.feature.md
+++ b/news/sso-apps-municipalities.feature.md
@@ -1,1 +1,0 @@
-Add `get_sso_apps_users_with_municipalities` utility (and the `_municipality_from_group_name` helper) that returns each access-group sso-apps user enriched with the municipality slugs derived from their `pl_<localite>` Keycloak groups. Intended to be called from a maintenance runscript that grants those users local roles on the matching Plone root folder. [remdub]

--- a/scripts/set_sso_apps_permissions.py
+++ b/scripts/set_sso_apps_permissions.py
@@ -1,0 +1,35 @@
+"""Grant sso-apps users local roles on their municipality root folder.
+
+All the logic lives in ``pas.plugins.kimug.utils.set_sso_apps_local_roles`` so
+this thin shim can be dropped, unchanged, into every instance that needs it
+(e.g. the directory, events and news buildouts).
+
+Run it (per instance) with::
+
+    bin/instance -O Plone run scripts/set_sso_apps_permissions.py
+    bin/instance -O Plone run scripts/set_sso_apps_permissions.py --dry-run
+
+The operation is idempotent (roles are merged, never overwritten) and safe to
+re-run. A summary is logged listing granted folders, users with no ``pl_``
+group, municipality slugs with no matching root folder, and users missing from
+Plone.
+"""
+from pas.plugins.kimug.utils import get_portal_from_zope_app
+from pas.plugins.kimug.utils import set_sso_apps_local_roles
+
+import argparse
+
+
+parser = argparse.ArgumentParser(description="Grant sso-apps users local roles")
+parser.add_argument("-c")  # swallowed by `bin/instance run`
+parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Only report what would change; do not set local roles or commit.",
+)
+
+
+if __name__ == "__main__":
+    args, _ = parser.parse_known_args()
+    portal = get_portal_from_zope_app(app)  # noqa: F821
+    set_sso_apps_local_roles(portal, dry_run=args.dry_run)

--- a/src/pas/plugins/kimug/browser/configure.zcml
+++ b/src/pas/plugins/kimug/browser/configure.zcml
@@ -44,6 +44,14 @@
       />
 
   <browser:page
+      name="set_sso_apps_permissions"
+      for="plone.base.interfaces.IPloneSiteRoot"
+      class=".view.SetSSOAppsPermissionsView"
+      permission="cmf.ManagePortal"
+      layer="pas.plugins.kimug.interfaces.IBrowserLayer"
+      />
+
+  <browser:page
       name="toggle_debug_mode"
       for="plone.base.interfaces.IPloneSiteRoot"
       class=".view.ToggleDebugModeView"

--- a/src/pas/plugins/kimug/browser/view.py
+++ b/src/pas/plugins/kimug/browser/view.py
@@ -6,6 +6,7 @@ from pas.plugins.kimug.utils import get_keycloak_users_from_oidc
 from pas.plugins.kimug.utils import get_keycloak_users_from_oidc_sso_apps
 from pas.plugins.kimug.utils import migrate_plone_user_id_to_keycloak_user_id
 from pas.plugins.kimug.utils import set_oidc_settings
+from pas.plugins.kimug.utils import set_sso_apps_local_roles
 from pas.plugins.oidc import _
 from pas.plugins.oidc import plugins
 from pas.plugins.oidc import utils
@@ -63,6 +64,24 @@ class KeycloakSSOAppsUsersView(BrowserView):
         added_users = add_keycloak_users_to_plone(keycloak_users)
         api.portal.show_message(
             f"{added_users} Keycloak sso apps users imported", self.request
+        )
+        referer = self.request.get("HTTP_REFERER")
+        if referer:
+            self.request.response.redirect(referer)
+        else:
+            self.request.response.redirect(self.context.absolute_url())
+
+
+class SetSSOAppsPermissionsView(BrowserView):
+    def __call__(self):
+        dry_run = self.request.get("dry-run") in ("1", "true", "True", "on")
+        summary = set_sso_apps_local_roles(self.context, dry_run=dry_run)
+        api.portal.show_message(
+            f"sso-apps local roles {'(dry-run) ' if dry_run else ''}set: "
+            f"{len(summary['granted'])} grants, "
+            f"{len(summary['missing_user'])} users missing in Plone, "
+            f"{len(summary['no_folder'])} slugs without a folder",
+            self.request,
         )
         referer = self.request.get("HTTP_REFERER")
         if referer:

--- a/src/pas/plugins/kimug/controlpanel/controlpanel.pt
+++ b/src/pas/plugins/kimug/controlpanel/controlpanel.pt
@@ -112,6 +112,20 @@
                 >
                   <span i18n:translate="">Add users from Keycloak sso apps in Plone</span>
                 </a>
+                <a class="btn btn-secondary mb-3"
+                   tal:attributes="
+                     href string:${context/absolute_url}/@@set_sso_apps_permissions?_authenticator=${context/@@authenticator/token};
+                   "
+                >
+                  <span i18n:translate="">Set sso-apps users local roles on their municipality folder</span>
+                </a>
+                <a class="btn btn-outline-secondary mb-3 ml-2"
+                   tal:attributes="
+                     href string:${context/absolute_url}/@@set_sso_apps_permissions?dry-run=1&amp;_authenticator=${context/@@authenticator/token};
+                   "
+                >
+                  <span i18n:translate="">Set sso-apps users local roles on their municipality folder Dry-run (report only, no changes)</span>
+                </a>
                 <h3 class="h6 text-uppercase text-muted"
                     i18n:translate=""
                 >Settings</h3>

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -904,6 +904,88 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
         return []
 
 
+def _municipality_from_group_name(name):
+    """Return the municipality slug for a Keycloak group named 'pl_<localite>'.
+
+    Keycloak may return the group as a leaf name ('pl_belleville') or as a path
+    ('/pl_belleville'); both are handled. Returns None for groups that do not
+    follow the 'pl_' convention.
+    """
+    if not name:
+        return None
+    name = name.lstrip("/")
+    if name.startswith("pl_"):
+        return name[3:]
+    return None
+
+
+def get_sso_apps_users_with_municipalities(timeout: int = 30):
+    """Get SSO apps users (filtered by access group) with their municipality slugs.
+
+    Builds on get_keycloak_users_from_oidc_sso_apps (which applies the
+    SSO_APPS_ACCESS_GROUP / SSO_APPS_MUNICIPALITY_GROUPS filtering) and attaches,
+    for each user, the list of municipality slugs derived from their
+    'pl_<localite>' Keycloak groups.
+
+    Returns a list of dicts with the same keys as
+    get_keycloak_users_from_oidc_sso_apps plus a "municipalities" list, e.g.
+    {username, email, keycloak_id, firstName, lastName, municipalities: [...]}.
+    Returns [] on any error.
+    """
+    users = get_keycloak_users_from_oidc_sso_apps(timeout=timeout)
+    if not users:
+        return []
+
+    oidc_sso_apps = get_plugin("oidc_sso_apps")
+    if not oidc_sso_apps:
+        logger.error("OIDC SSO Apps plugin not found")
+        return []
+    issuer = oidc_sso_apps.issuer
+    issuer_parsed = urlparse(issuer) if issuer else None
+    if not issuer_parsed or not issuer_parsed.scheme or not issuer_parsed.netloc:
+        logger.error("OIDC SSO Apps issuer is not a valid URL")
+        return []
+
+    realm = "sso-apps"
+    keycloak_url = f"{issuer_parsed.scheme}://{issuer_parsed.netloc}/"
+    access_token = get_client_access_token(
+        keycloak_url, realm, oidc_sso_apps.client_id, oidc_sso_apps.client_secret
+    )
+    if access_token is None:
+        logger.error(
+            "Could not get access token from Keycloak with OIDC settings for sso-apps plugin"
+        )
+        return []
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    enriched = []
+    try:
+        for user in users:
+            keycloak_id = user.get("keycloak_id")
+            municipalities = []
+            if keycloak_id:
+                groups_url = (
+                    f"{keycloak_url}admin/realms/{realm}/users/{keycloak_id}/groups"
+                )
+                response = requests.get(
+                    url=groups_url, headers=headers, timeout=timeout
+                )
+                response.raise_for_status()
+                for group in response.json():
+                    municipality = _municipality_from_group_name(group.get("name"))
+                    if municipality and municipality not in municipalities:
+                        municipalities.append(municipality)
+            enriched.append({**user, "municipalities": municipalities})
+        logger.info(f"Resolved municipalities for {len(enriched)} sso-apps users")
+        return enriched
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error fetching user groups from Keycloak: {e}")
+        return []
+    except ValueError as e:
+        logger.error(f"Error parsing user groups response: {e}")
+        return []
+
+
 def add_keycloak_users_to_plone(users):
     """Add Keycloak users to Plone if they do not already exist."""
     oidc = get_plugin("oidc")

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -794,7 +794,7 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
     if not oidc_sso_apps:
         logger.error("OIDC SSO Apps plugin not found")
         return []
-    realm = "sso-apps"
+    realm = os.environ.get("SSO_APPS_REALM", "sso-apps")
     issuer = oidc_sso_apps.issuer
     if not issuer:
         logger.error("OIDC SSO Apps issuer not set")
@@ -950,7 +950,7 @@ def get_sso_apps_users_with_municipalities(timeout: int = 30):
         logger.error("OIDC SSO Apps issuer is not a valid URL")
         return []
 
-    realm = "sso-apps"
+    realm = os.environ.get("SSO_APPS_REALM", "sso-apps")
     keycloak_url = f"{issuer_parsed.scheme}://{issuer_parsed.netloc}/"
     access_token = get_client_access_token(
         keycloak_url, realm, oidc_sso_apps.client_id, oidc_sso_apps.client_secret

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -990,6 +990,140 @@ def get_sso_apps_users_with_municipalities(timeout: int = 30):
         return []
 
 
+SSO_APPS_LOCAL_ROLES = ("Contributor", "Editor", "Reader")
+
+
+def resolve_sso_apps_userid(user):
+    """Return the Plone userid for an sso-apps user, or None if absent in Plone.
+
+    sso-apps users are created with their keycloak_id as the Plone userid
+    (see add_keycloak_users_to_plone / oidc._create_user), but resolve via the
+    username first so we use whatever id Plone actually stored.
+    """
+    member = api.user.get(username=user.get("username"))
+    if member is not None:
+        return member.getId()
+    keycloak_id = user.get("keycloak_id")
+    if keycloak_id and api.user.get(userid=keycloak_id) is not None:
+        return keycloak_id
+    return None
+
+
+def set_sso_apps_local_roles(portal=None, dry_run=False):
+    """Grant sso-apps users local roles on their municipality root folder.
+
+    For every Keycloak sso-apps user that holds the configured access group
+    (SSO_APPS_ACCESS_GROUP), read their ``pl_<localite>`` groups and, when a
+    Plone root object exists with id exactly ``<localite>``, grant the user the
+    Contributor/Editor/Reader local roles on that folder.
+
+    The operation is idempotent (roles are merged, never overwritten) and safe
+    to re-run. Returns a summary dict with the keys ``granted``, ``no_group``,
+    ``no_folder``, ``missing_user`` and ``dry_run``.
+    """
+    if portal is None:
+        portal = api.portal.get()
+
+    users = get_sso_apps_users_with_municipalities()
+    logger.info(f"Fetched {len(users)} sso-apps users from Keycloak")
+    root_ids = set(portal.objectIds())
+
+    granted = []  # (username, userid, localite)
+    no_group = []  # username
+    no_folder = []  # (username, localite)
+    missing_user = []  # username
+
+    for user in users:
+        username = user.get("username")
+        userid = resolve_sso_apps_userid(user)
+        if userid is None:
+            missing_user.append(username)
+            logger.warning(f"User '{username}' not found in Plone, skipping")
+            continue
+
+        municipalities = user.get("municipalities") or []
+        if not municipalities:
+            no_group.append(username)
+            continue
+
+        for localite in municipalities:
+            if localite not in root_ids:
+                no_folder.append((username, localite))
+                continue
+            folder = portal[localite]
+            current = set(folder.get_local_roles_for_userid(userid))
+            new_roles = sorted(current | set(SSO_APPS_LOCAL_ROLES))
+            if not dry_run:
+                folder.manage_setLocalRoles(userid, new_roles)
+                folder.reindexObjectSecurity()
+            granted.append((username, userid, localite))
+            logger.info(
+                f"{'[dry-run] would grant' if dry_run else 'Granted'} "
+                f"{list(SSO_APPS_LOCAL_ROLES)} to '{username}' ({userid}) on /{localite}"
+            )
+
+    logger.info("=== sso-apps local roles summary ===")
+    logger.info(f"Granted on a folder : {len(granted)}")
+    logger.info(f"Users without pl_ group : {len(no_group)} -> {sorted(no_group)}")
+    logger.info(
+        f"Municipality slugs without matching root folder : {len(no_folder)} -> "
+        f"{sorted(no_folder)}"
+    )
+    logger.info(
+        f"Users missing in Plone : {len(missing_user)} -> {sorted(missing_user)}"
+    )
+
+    if dry_run:
+        logger.info("Dry-run: no changes committed")
+    else:
+        try:
+            transaction.commit()
+            logger.info("Transaction committed")
+        except ConflictError:
+            transaction.abort()
+            logger.warning(
+                "ConflictError committing sso-apps local roles: another instance "
+                "already committed the same values; skipping."
+            )
+
+    return {
+        "granted": granted,
+        "no_group": no_group,
+        "no_folder": no_folder,
+        "missing_user": missing_user,
+        "dry_run": dry_run,
+    }
+
+
+def get_portal_from_zope_app(zope_app, user_id="admin"):
+    """Bootstrap a Zope ``bin/instance run`` context and return the Plone site.
+
+    Sets up a request, authenticates as ``user_id`` and locates the first
+    Plone site under the Zope application root. Imports are local so this
+    runscript-only machinery is not pulled into normal request handling.
+    """
+    from AccessControl.SecurityManagement import newSecurityManager
+    from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+    from Testing import makerequest
+    from zope.globalrequest import setRequest
+
+    zope_app = makerequest.makerequest(zope_app)
+    zope_app.REQUEST["PARENTS"] = [zope_app]
+    setRequest(zope_app.REQUEST)
+    user = zope_app.acl_users.getUser(user_id)
+    newSecurityManager(None, user.__of__(zope_app.acl_users))
+    portal = None
+    for oid in zope_app.objectIds():
+        obj = zope_app[oid]
+        if IPloneSiteRoot.providedBy(obj):
+            portal = obj
+            break
+    if not portal:
+        raise Exception("Can't find portal !")
+    setSite(portal)
+    return portal
+
+
 def add_keycloak_users_to_plone(users):
     """Add Keycloak users to Plone if they do not already exist."""
     oidc = get_plugin("oidc")

--- a/src/pas/plugins/kimug/utils.py
+++ b/src/pas/plugins/kimug/utils.py
@@ -905,18 +905,22 @@ def get_keycloak_users_from_oidc_sso_apps(timeout: int = 30):
 
 
 def _municipality_from_group_name(name):
-    """Return the municipality slug for a Keycloak group named 'pl_<localite>'.
+    """Return the municipality slug for a Keycloak group named 'pl_<municipality>-<type>'.
 
-    Keycloak may return the group as a leaf name ('pl_belleville') or as a path
-    ('/pl_belleville'); both are handled. Returns None for groups that do not
-    follow the 'pl_' convention.
+    Group names follow the 'pl_<municipality>-<type>' convention, e.g. 'pl_amay-ac',
+    'pl_amay-cpas', 'pl_imio-ic-demo-client'. The municipality is the segment between
+    the 'pl_' prefix and the first hyphen; everything after the first hyphen is the
+    entity type (ac, cpas, ic, prov, zs, ...). Keycloak may return the group as a leaf
+    name ('pl_amay-ac') or as a path ('/pl_amay-ac'); both are handled. Returns None for
+    groups that do not follow the 'pl_' convention.
     """
     if not name:
         return None
     name = name.lstrip("/")
-    if name.startswith("pl_"):
-        return name[3:]
-    return None
+    if not name.startswith("pl_"):
+        return None
+    municipality = name[3:].split("-", 1)[0]
+    return municipality or None
 
 
 def get_sso_apps_users_with_municipalities(timeout: int = 30):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -493,11 +493,17 @@ class TestGetKeycloakUsersFromOidcSsoApps:
 
 
 class TestMunicipalityFromGroupName:
-    def test_strips_pl_prefix(self):
-        assert utils._municipality_from_group_name("pl_belleville") == "belleville"
+    def test_strips_pl_prefix_and_type_suffix(self):
+        assert utils._municipality_from_group_name("pl_amay-ac") == "amay"
+
+    def test_cpas_variant_yields_same_slug_as_ac(self):
+        assert utils._municipality_from_group_name("pl_amay-cpas") == "amay"
 
     def test_strips_leading_slash_path(self):
-        assert utils._municipality_from_group_name("/pl_belleville") == "belleville"
+        assert utils._municipality_from_group_name("/pl_amay-ac") == "amay"
+
+    def test_multi_segment_type_is_stripped(self):
+        assert utils._municipality_from_group_name("pl_imio-ic-demo-client") == "imio"
 
     def test_non_pl_group_returns_none(self):
         assert utils._municipality_from_group_name("access_imio-apps-kimug") is None
@@ -534,11 +540,11 @@ class TestGetSsoAppsUsersWithMunicipalities:
         return user
 
     def test_attaches_municipality(self, portal):
-        """The 'pl_<localite>' group is stripped to a municipality slug."""
+        """The 'pl_<municipality>-<type>' group is stripped to a municipality slug."""
         self._configure_plugin()
         base_users = [self._base_user()]
         user_groups = [
-            {"id": "g1", "name": "pl_belleville", "path": "/pl_belleville"},
+            {"id": "g1", "name": "pl_belleville-ac", "path": "/pl_belleville-ac"},
             {"id": "g2", "name": "access_imio-apps-kimug"},
         ]
         with patch(
@@ -555,13 +561,14 @@ class TestGetSsoAppsUsersWithMunicipalities:
         assert result == [{**base_users[0], "municipalities": ["belleville"]}]
 
     def test_multiple_municipalities_deduplicated(self, portal):
-        """A user in several 'pl_' groups gets all slugs; duplicates collapse; paths handled."""
+        """A user in several 'pl_' groups gets all slugs; AC/CPAS variants of the
+        same locality collapse to one slug; paths handled."""
         self._configure_plugin()
         base_users = [self._base_user(username="bob", keycloak_id="uid-2")]
         user_groups = [
-            {"name": "pl_belleville"},
-            {"name": "/pl_another"},
-            {"name": "pl_belleville"},
+            {"name": "pl_belleville-ac"},
+            {"name": "/pl_another-ic"},
+            {"name": "pl_belleville-cpas"},
             {"name": "some-other-group"},
         ]
         with patch(

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -492,6 +492,135 @@ class TestGetKeycloakUsersFromOidcSsoApps:
         assert usernames == ["alice", "bob"]
 
 
+class TestMunicipalityFromGroupName:
+    def test_strips_pl_prefix(self):
+        assert utils._municipality_from_group_name("pl_belleville") == "belleville"
+
+    def test_strips_leading_slash_path(self):
+        assert utils._municipality_from_group_name("/pl_belleville") == "belleville"
+
+    def test_non_pl_group_returns_none(self):
+        assert utils._municipality_from_group_name("access_imio-apps-kimug") is None
+
+    def test_empty_or_none_returns_none(self):
+        assert utils._municipality_from_group_name("") is None
+        assert utils._municipality_from_group_name(None) is None
+
+
+class TestGetSsoAppsUsersWithMunicipalities:
+    def _configure_plugin(self):
+        plugin = utils.get_plugin("oidc_sso_apps")
+        plugin.issuer = "https://sso.example.com/realms/sso-apps"
+        plugin.client_id = "test-client"
+        plugin.client_secret = "test-secret"
+        plugin.municipality_groups = ()
+        return plugin
+
+    def _mock_response(self, data):
+        resp = MagicMock()
+        resp.json.return_value = data
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def _base_user(self, **overrides):
+        user = {
+            "username": "alice",
+            "email": "alice@example.com",
+            "keycloak_id": "uid-1",
+            "firstName": "Alice",
+            "lastName": "Smith",
+        }
+        user.update(overrides)
+        return user
+
+    def test_attaches_municipality(self, portal):
+        """The 'pl_<localite>' group is stripped to a municipality slug."""
+        self._configure_plugin()
+        base_users = [self._base_user()]
+        user_groups = [
+            {"id": "g1", "name": "pl_belleville", "path": "/pl_belleville"},
+            {"id": "g2", "name": "access_imio-apps-kimug"},
+        ]
+        with patch(
+            "pas.plugins.kimug.utils.get_keycloak_users_from_oidc_sso_apps",
+            return_value=base_users,
+        ):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [self._mock_response(user_groups)]
+                    result = utils.get_sso_apps_users_with_municipalities()
+
+        assert result == [{**base_users[0], "municipalities": ["belleville"]}]
+
+    def test_multiple_municipalities_deduplicated(self, portal):
+        """A user in several 'pl_' groups gets all slugs; duplicates collapse; paths handled."""
+        self._configure_plugin()
+        base_users = [self._base_user(username="bob", keycloak_id="uid-2")]
+        user_groups = [
+            {"name": "pl_belleville"},
+            {"name": "/pl_another"},
+            {"name": "pl_belleville"},
+            {"name": "some-other-group"},
+        ]
+        with patch(
+            "pas.plugins.kimug.utils.get_keycloak_users_from_oidc_sso_apps",
+            return_value=base_users,
+        ):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [self._mock_response(user_groups)]
+                    result = utils.get_sso_apps_users_with_municipalities()
+
+        assert result[0]["municipalities"] == ["belleville", "another"]
+
+    def test_no_pl_group_yields_empty_municipalities(self, portal):
+        """A user with no 'pl_' group gets an empty municipalities list."""
+        self._configure_plugin()
+        base_users = [self._base_user(username="carol", keycloak_id="uid-3")]
+        user_groups = [{"name": "access_imio-apps-kimug"}]
+        with patch(
+            "pas.plugins.kimug.utils.get_keycloak_users_from_oidc_sso_apps",
+            return_value=base_users,
+        ):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = [self._mock_response(user_groups)]
+                    result = utils.get_sso_apps_users_with_municipalities()
+
+        assert result[0]["municipalities"] == []
+
+    def test_no_users_returns_empty_list(self, portal):
+        """If no eligible sso-apps users, return [] without further calls."""
+        with patch(
+            "pas.plugins.kimug.utils.get_keycloak_users_from_oidc_sso_apps",
+            return_value=[],
+        ):
+            result = utils.get_sso_apps_users_with_municipalities()
+        assert result == []
+
+    def test_request_exception_returns_empty_list(self, portal):
+        """A RequestException while fetching user groups is caught and [] returned."""
+        self._configure_plugin()
+        base_users = [self._base_user(username="dave", keycloak_id="uid-4")]
+        with patch(
+            "pas.plugins.kimug.utils.get_keycloak_users_from_oidc_sso_apps",
+            return_value=base_users,
+        ):
+            with patch(
+                "pas.plugins.kimug.utils.get_client_access_token", return_value="tok"
+            ):
+                with patch("pas.plugins.kimug.utils.requests.get") as mock_get:
+                    mock_get.side_effect = requests.exceptions.RequestException("boom")
+                    result = utils.get_sso_apps_users_with_municipalities()
+        assert result == []
+
+
 class TestSetOidcSettings:
     def test_conflict_error_is_handled(self, portal):
         """ConflictError on commit must be caught and transaction aborted — no exception raised."""

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -628,6 +628,130 @@ class TestGetSsoAppsUsersWithMunicipalities:
         assert result == []
 
 
+class TestSetSsoAppsLocalRoles:
+    def _make_user(self, userid, username, email):
+        return api.user.create(
+            email=email,
+            username=username,
+            password="Secret123!",
+            properties={"username": username},
+        )
+
+    def _user_dict(self, **overrides):
+        user = {
+            "username": "alice",
+            "email": "alice@example.com",
+            "keycloak_id": "uid-1",
+            "firstName": "Alice",
+            "lastName": "Smith",
+            "municipalities": ["belleville"],
+        }
+        user.update(overrides)
+        return user
+
+    def test_grants_local_roles_on_matching_folder(self, portal):
+        """A user with a 'belleville' municipality gets the local roles on /belleville."""
+        with api.env.adopt_roles(["Manager"]):
+            self._make_user("alice", "alice", "alice@example.com")
+            folder = api.content.create(
+                container=portal, type="Folder", id="belleville", title="Belleville"
+            )
+            with patch(
+                "pas.plugins.kimug.utils.get_sso_apps_users_with_municipalities",
+                return_value=[self._user_dict()],
+            ):
+                with patch("pas.plugins.kimug.utils.transaction"):
+                    summary = utils.set_sso_apps_local_roles(portal)
+
+            roles = folder.get_local_roles_for_userid("alice")
+        assert set(utils.SSO_APPS_LOCAL_ROLES).issubset(set(roles))
+        assert [(u, uid, loc) for (u, uid, loc) in summary["granted"]] == [
+            ("alice", "alice", "belleville")
+        ]
+        assert summary["dry_run"] is False
+
+    def test_dry_run_makes_no_changes(self, portal):
+        """With dry_run=True the summary reports the grant but no role is set."""
+        user = self._user_dict(
+            username="bob", keycloak_id="uid-2", municipalities=["namur"]
+        )
+        with api.env.adopt_roles(["Manager"]):
+            self._make_user("bob", "bob", "bob@example.com")
+            folder = api.content.create(
+                container=portal, type="Folder", id="namur", title="Namur"
+            )
+            with patch(
+                "pas.plugins.kimug.utils.get_sso_apps_users_with_municipalities",
+                return_value=[user],
+            ):
+                with patch("pas.plugins.kimug.utils.transaction") as mock_txn:
+                    summary = utils.set_sso_apps_local_roles(portal, dry_run=True)
+
+            local_roles = folder.get_local_roles_for_userid("bob")
+        assert local_roles == ()
+        assert summary["dry_run"] is True
+        assert len(summary["granted"]) == 1
+        mock_txn.commit.assert_not_called()
+
+    def test_missing_user_and_missing_folder_are_reported(self, portal):
+        """Users absent from Plone and slugs without a folder land in the summary."""
+        users = [
+            self._user_dict(username="carol", municipalities=["ghost-town"]),
+            self._user_dict(username="ghost", keycloak_id="uid-99"),
+        ]
+        with api.env.adopt_roles(["Manager"]):
+            self._make_user("carol", "carol", "carol@example.com")
+            with patch(
+                "pas.plugins.kimug.utils.get_sso_apps_users_with_municipalities",
+                return_value=users,
+            ):
+                with patch("pas.plugins.kimug.utils.transaction"):
+                    summary = utils.set_sso_apps_local_roles(portal)
+
+        assert ("carol", "ghost-town") in summary["no_folder"]
+        assert "ghost" in summary["missing_user"]
+        assert summary["granted"] == []
+
+    def test_idempotent_merges_existing_roles(self, portal):
+        """An existing unrelated local role is preserved when the roles are merged."""
+        user = self._user_dict(
+            username="dave", keycloak_id="uid-3", municipalities=["liege"]
+        )
+        with api.env.adopt_roles(["Manager"]):
+            self._make_user("dave", "dave", "dave@example.com")
+            folder = api.content.create(
+                container=portal, type="Folder", id="liege", title="Liege"
+            )
+            folder.manage_setLocalRoles("dave", ["Reviewer"])
+            with patch(
+                "pas.plugins.kimug.utils.get_sso_apps_users_with_municipalities",
+                return_value=[user],
+            ):
+                with patch("pas.plugins.kimug.utils.transaction"):
+                    utils.set_sso_apps_local_roles(portal)
+
+            roles = set(folder.get_local_roles_for_userid("dave"))
+        assert "Reviewer" in roles
+        assert set(utils.SSO_APPS_LOCAL_ROLES).issubset(roles)
+
+    def test_conflict_error_is_handled(self, portal):
+        """A ConflictError on commit is caught and the transaction aborted."""
+        user = self._user_dict(
+            username="erin", keycloak_id="uid-4", municipalities=["mons"]
+        )
+        with api.env.adopt_roles(["Manager"]):
+            self._make_user("erin", "erin", "erin@example.com")
+            api.content.create(container=portal, type="Folder", id="mons", title="Mons")
+            with patch(
+                "pas.plugins.kimug.utils.get_sso_apps_users_with_municipalities",
+                return_value=[user],
+            ):
+                with patch("pas.plugins.kimug.utils.transaction") as mock_txn:
+                    mock_txn.commit.side_effect = ConflictError()
+                    utils.set_sso_apps_local_roles(portal)
+                    mock_txn.abort.assert_called_once()
+
+
 class TestSetOidcSettings:
     def test_conflict_error_is_handled(self, portal):
         """ConflictError on commit must be caught and transaction aborted — no exception raised."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added control panel actions to set SSO-app users’ local roles on municipality folders, including a dry-run preview/report.
  * Introduced municipality-group based syncing and role assignment, with configurable Keycloak realm for SSO-apps.
  * Added an executable run tool to apply (or report-only) SSO-app permissions from the command line.
* **Tests**
  * Added coverage for municipality parsing, user import enrichment, and local-role assignment behaviors (including dry-run and conflict handling).
* **Chores**
  * Updated the changelog for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->